### PR TITLE
Make return type to JSX for all functions

### DIFF
--- a/src/Router.purs
+++ b/src/Router.purs
@@ -3,5 +3,5 @@ module React.Basic.Router
   )
   where
 
-import React.Basic.Router.Foreign (link, redirect, route, switch) as Router
 import React.Basic.Router.DelayedRedirect (delayedRedirect) as Router
+import React.Basic.Router.Wrapper (link, redirect, route, switch) as Router

--- a/src/Router/Foreign.purs
+++ b/src/Router/Foreign.purs
@@ -3,13 +3,14 @@ module React.Basic.Router.Foreign where
 import Data.Function.Uncurried (Fn0, runFn0)
 import React.Basic.Classic (ReactComponent)
 import React.Basic.Router.Types
+import React.Basic.Router.Types.Foreign as ForeignTypes
 
-foreign import route_ :: forall p. Fn0 (ReactComponent (RouteProps p))
+foreign import route_ :: forall p. Fn0 (ReactComponent (ForeignTypes.RouteProps p))
 foreign import switch_ :: Fn0 (ReactComponent SwitchProps)
 foreign import link_ :: forall p state. Fn0 (ReactComponent (LinkProps p state))
 foreign import redirect_ :: forall state. Fn0 (ReactComponent (RedirectProps state))
 
-route :: forall props. ReactComponent (RouteProps props)
+route :: forall props. ReactComponent (ForeignTypes.RouteProps props)
 route = runFn0 route_
 
 switch :: ReactComponent SwitchProps

--- a/src/Router/Types.purs
+++ b/src/Router/Types.purs
@@ -1,5 +1,6 @@
 module React.Basic.Router.Types where
 
+import Data.Maybe (Maybe)
 import Data.Nullable (Nullable)
 import Foreign (Foreign)
 import React.Basic.Classic (JSX)
@@ -40,7 +41,7 @@ type SwitchProps = { children :: Array JSX }
 
 type RouteProps jsProps =
   { exact :: Boolean
-  , path :: Nullable String
+  , path :: Maybe String
   , render :: jsProps -> JSX
   }
 

--- a/src/Router/Types/Foreign.purs
+++ b/src/Router/Types/Foreign.purs
@@ -1,0 +1,10 @@
+module React.Basic.Router.Types.Foreign where
+
+import Data.Nullable (Nullable)
+import React.Basic.Classic (JSX)
+
+type RouteProps jsProps =
+  { exact :: Boolean
+  , path :: Nullable String
+  , render :: jsProps -> JSX
+  }

--- a/src/Router/Wrapper.purs
+++ b/src/Router/Wrapper.purs
@@ -1,0 +1,18 @@
+module React.Basic.Router.Wrapper where
+
+import Data.Nullable (toNullable)
+import React.Basic (element, JSX)
+import React.Basic.Router.Foreign as Foreign
+import React.Basic.Router.Types
+
+route :: forall props. RouteProps props -> JSX
+route { exact, path, render } = element Foreign.route { exact: exact, path: toNullable path, render }
+
+switch :: SwitchProps -> JSX
+switch = element Foreign.switch
+
+link :: forall props state. LinkProps props state -> JSX
+link = element Foreign.link
+
+redirect :: forall state. RedirectProps state -> JSX
+redirect = element Foreign.redirect


### PR DESCRIPTION
This turns the thinly wrapped ReactComponents into a bit more wrapped JSX functions. Also, `RouteProps` has had its `Nullable` changed into a `Maybe`. The changes needed to Affresco are dropping a few `element` and `toNullable` calls.

I didn't touch `Location`'s `state` field and it still has a `Nullable`. Looking at how `Location` is used in Prenumerera, I would hope that there'd be some other way to use it without going so much to jsprops and back and `Maybe`/`Nullable` usage would be subsumed into that.