### PR TITLE
Add explicit exports of types not used in functions

### DIFF
--- a/src/Router.purs
+++ b/src/Router.purs
@@ -4,4 +4,5 @@ module React.Basic.Router
   where
 
 import React.Basic.Router.DelayedRedirect (delayedRedirect) as Router
+import React.Basic.Router.Types (Location, JSRouterProps, Match) as Router
 import React.Basic.Router.Wrapper (link, redirect, route, switch) as Router


### PR DESCRIPTION
Turns out that somehow my last changes made Prenumerera not find some types it previously found without explicit exports of them.

Looks also like we exploited some type checker bug in purescript compiler in Prenumerera and I don't think it should even have compiled, we're completely been discarding a `Nullable` in purescript-react-basic-router's `Location` type. I'll make a pull request fixing that once I have a new hash available for purescript-react-basic-router.